### PR TITLE
Add nginx hosting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "bento/centos-8"
+  config.vm.box = "ubuntu/focal64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -43,7 +43,8 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  # config.vm.synced_folder "./data", "/vagrant_data"
+  # config.vm.synced_folder ".", "/vagrant"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -64,12 +65,21 @@ Vagrant.configure("2") do |config|
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
    config.vm.provision "shell", inline: <<-SHELL
-       dnf --quiet -y install python3 git
-       pip install --upgrade pip
-       python3 --version
-       pip3 --version
-       python --version
-       pip --version
-       git --version
+        # Install Python3 and Git
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update; sudo apt-get upgrade
+        apt --quiet -y install python3 python3-pip python3-venv git
+        pip install --upgrade pip
+        python3 --version
+        pip3 --version
+        python --version
+        pip --version
+        git --version
+        # Install and Start NGinX
+        apt-get -q -y install nginx
+        cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.old
+        cp /vagrant/nginx.conf /etc/nginx/nginx.conf
+        systemctl start nginx
+        systemctl enable nginx
    SHELL
 end

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,103 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user www-data;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    server_names_hash_bucket_size 64;
+    # Stupid server_names_hash_bucket size
+    # https://stackoverflow.com/a/64935503/2146138
+    server_names_hash_max_size 512;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+#    server {
+#        listen       80;
+#        listen       [::]:80;
+#        server_name  dmassistant;
+#        root         /usr/share/nginx/html;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+
+    # Forward port 8000 to 80 for Python app
+    server {
+        listen 80;
+        server_name 192.168.33.10; # Change to correct DNS or IP Address
+        access_log  /var/log/nginx/access.log;
+    
+        location / {
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2;
+#        listen       [::]:443 ssl http2;
+#        server_name  _;
+#        root         /usr/share/nginx/html;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /etc/nginx/default.d/*.conf;
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}
+

--- a/web_app.py
+++ b/web_app.py
@@ -163,4 +163,9 @@ if __name__ == "__main__":
 
     # This runs the app. This won't be run if
     # web_app gets imported.
-    dmapp.run()
+    dmapp.run(addr="0.0.0.0",
+        port=8000,
+        debug=None,
+        static_url_path=None,
+        static_root=None,
+    )


### PR DESCRIPTION
WARNING: This allows traffic from 0.0.0.0, to make sure
Vagrant works correctly.

Might not be wise to use in prod.

Consider overriding via CLI rather than putting it into
the source code?

The cool part is that after `vagrant up` and `vagrant ssh`, installing the requirements with `pip install -r requirements.txt` and starting up the server with `python3 web_app.py`, you should be able to see the server by visiting 192.168.33.10 in your browser.